### PR TITLE
user_config.tcl: setup env(VERILOG_INCLUDE_DIRS)

### DIFF
--- a/project.py
+++ b/project.py
@@ -32,6 +32,7 @@ def create_user_config(yaml):
             if line != len(sources) - 1:
                 fh.write(' \\\n')
         fh.write('"\n')
+        fh.write("set ::env(VERILOG_INCLUDE_DIRS) \"$::env(DESIGN_DIR)/include $::env(DESIGN_DIR)\"\n")
 
 
 def fetch_file(url, filename):


### PR DESCRIPTION
An experiment showed that the colon character is not used as path separator like $PATH.
A whitespace worked, like the $VERILOG_FILES setup.

Docs link: https://openlane.readthedocs.io/en/latest/reference/configuration.html#synthesis

This adds:
 ${DESIGN_DIR}/include
 ${DESIGN_DIR}

The addition of the "include" directory can allow a project to manage includes in a subdir (as an option)