### PR TITLE
Increase the bottom margin to show page number

### DIFF
--- a/docs/project_header.md
+++ b/docs/project_header.md
@@ -1,6 +1,6 @@
 ---
 documentclass: scrartcl
-geometry: margin=2cm
+geometry: "left=2cm,right=2cm,top=2cm,bottom=3cm"
 fontsize: 14pt
 mainfont: Latin Modern Sans
 header-includes:


### PR DESCRIPTION
Previously with the 2cm bottom margin, the documentation was cutting off the page number about half way, so I increase the bottom margin from 2 to 3cm.

Before:
![image](https://github.com/TinyTapeout/tt-support-tools/assets/34654485/049ce5e0-cf63-4c29-8431-bf343312f21c)

After:
![image](https://github.com/TinyTapeout/tt-support-tools/assets/34654485/d0e673d1-10b1-4b88-8535-b9e33b45e31f)
