### PR TITLE
TT04 support via new truthtable format

### DIFF
--- a/testing/lib/testutils/truthtable.py
+++ b/testing/lib/testutils/truthtable.py
@@ -258,8 +258,8 @@ class TruthTable:
 		
 	async def testAll(self, clk, reset_n, i_bus, o_bus , logger=None):	
 		for i in range(len(self)):
-			reset_n.value = self[i].ctrl[0]
-			clk.value = self[i].ctrl[1]
+			reset_n.value = self[i].ctrl[1]
+			clk.value = self[i].ctrl[0]
 			i_bus.value = self[i].state
 			await Timer(self.stepDelayTime, units=self.stepDelayUnits)  # wait a tad
 			

--- a/testing/lib/testutils/truthtable.py
+++ b/testing/lib/testutils/truthtable.py
@@ -258,8 +258,8 @@ class TruthTable:
 		
 	async def testAll(self, reset_n, clk, i_bus, o_bus , logger=None):	
 		for i in range(len(self)):
-			reset_n.value = self[i].ctrl[0]
-			clk.value = self[i].ctrl[1]
+			reset_n.value = self[i].ctrl[1]
+			clk.value = self[i].ctrl[0]
 			i_bus.value = self[i].state
 			await Timer(self.stepDelayTime, units=self.stepDelayUnits)  # wait a tad
 			

--- a/testing/lib/testutils/truthtable.py
+++ b/testing/lib/testutils/truthtable.py
@@ -256,7 +256,7 @@ class TruthTable:
 		print(str(self))
 		
 		
-	async def testAll(self, clk, reset_n, i_bus, o_bus , logger=None):	
+	async def testAll(self, reset_n, clk, i_bus, o_bus , logger=None):	
 		for i in range(len(self)):
 			reset_n.value = self[i].ctrl[0]
 			clk.value = self[i].ctrl[1]

--- a/testing/lib/testutils/truthtable.py
+++ b/testing/lib/testutils/truthtable.py
@@ -269,7 +269,9 @@ class TruthTable:
 				
 			expectedResult = self[i].result
 			if logger is not None:
-				logger.info(f'State {i}, setting input to {self[i].state}, expecting {expectedResult} (got {o_bus.value})')
+				if len(self[i].comment):
+					logger.info(self[i].comment)
+				logger.info(f'State {i}, setting input to {self[i].ctrl} {self[i].state}, expecting {expectedResult} (got {o_bus.value})')
 				
 			# this is so stupid that it's probably wrong... there _must_ be
 			# a good way to do this, otherwise _what_ is the point of having
@@ -281,6 +283,7 @@ class TruthTable:
 				if expectedResult.hardBit[bit]:
 					# ok, safe to compare, duh
 					# logger.info(f'Doing bit {bit}: {o_bus[bit]} == {expectedResult[bit]}')
+					
 					assert o_bus[bit] == expectedResult[bit]
 		
 		

--- a/testing/lib/testutils/truthtable.py
+++ b/testing/lib/testutils/truthtable.py
@@ -258,8 +258,8 @@ class TruthTable:
 		
 	async def testAll(self, clk, reset_n, i_bus, o_bus , logger=None):	
 		for i in range(len(self)):
-			reset_n.value = self[i].ctrl[1]
-			clk.value = self[i].ctrl[0]
+			reset_n.value = self[i].ctrl[0]
+			clk.value = self[i].ctrl[1]
 			i_bus.value = self[i].state
 			await Timer(self.stepDelayTime, units=self.stepDelayUnits)  # wait a tad
 			

--- a/testing/src-tpl/test.py
+++ b/testing/src-tpl/test.py
@@ -24,5 +24,4 @@ async def truthTableCompare(parentDUT):
         return 
     
     usermodule._log.debug(str(tt))
-    await tt.testAll(i_bus, o_bus, usermodule._log)
-
+    await tt.testAll(parentDUT.rst_n, parentDUT.clk, i_bus, o_bus, usermodule._log)

--- a/testing/src-tpl/test_wokwi.v
+++ b/testing/src-tpl/test_wokwi.v
@@ -3,16 +3,29 @@
 `default_nettype none
 
 module test_wokwi ();
-  wire [7:0] uo_out;
-  wire [7:0] ui_in;
+    reg  clk; 			// clock
+    reg  rst_n;			// not reset
+    reg  ena;			// enable - goes high when design is selected
+    reg  [7:0] ui_in;		// dedicated inputs
+    reg  [7:0] uio_in;		// IOs: input path
+    
+    wire [7:0] uo_out;		// dedicated outputs
+    wire [7:0] uio_out;		// IOs: Output path
+    wire [7:0] uio_oe;		// IOs: Enable path (active high: 0=input, 1=output)
 
   tt_um_wokwi_WOKWI_ID dut (
   `ifdef GL_TEST
       .vccd1( 1'b1),
       .vssd1( 1'b0),
   `endif
-      .ui_in(ui_in),
-      .uo_out(uo_out)
+      .ui_in      (ui_in),    
+      .uo_out     (uo_out),   
+      .uio_in     (uio_in),   
+      .uio_out    (uio_out),  
+      .uio_oe     (uio_oe),   
+      .ena        (ena),      
+      .clk        (clk),     
+      .rst_n      (rst_n)    
   );
 
   initial begin


### PR DESCRIPTION
TT04 (partial) support via this new table format, where the ~reset and clock and split out and prepended before the 8 inputs.  

The ordering is hard (~RST and CLK in first column, in that order), followed by a column of 8 inputs, followed by a column of 8 outputs.  Comments column optional, use it throughout or not at all.  White spaces are ignored.

E.g. here is the table from the 7-seg display sample (https://wokwi.com/projects/347497504164545108 )
`
|RC| D  C  B  A  CDIS xxx |    segments     |        comment         |
|--|----------------------|-----------------|------------------------|
|00| 0  0  0  0    0  000 |   ---- ----     |    reset               |
|1x| 0  0  0  0    1  000 |   -111 1000     |    disable clocking    |
|xx| 0  0  0  1    x  xxx |   -111 1011     |    0b0001 (AB'C'D')    |
|xx| 0  0  1  0    x  xxx |   -000 0000     |    0b0010 (A'BC'D')    |
|xx| 0  1  0  0    x  xxx |   -101 0100     |    0b0100 (A'B'CD')    |
|xx| 1  0  0  0    x  xxx |   -001 0000     |    0b1000 (A'B'C'D)    |
|xx| 1  0  0  1    x  xxx |   -101 1100     |    AB'C'D: "o"         |
|xx| 1  0  0  1    0  x0x |   ---- ----     |  enable clocking+reset |
|xc| x  x  x  x    x  xxx |   -111 1000     |    T                   |
|xc| x  x  x  x    x  xxx |   -001 0000     |    i                   |
|xc| x  x  x  x    x  xxx |   -101 0100     |    n                   |
|xc| x  x  x  x    x  xxx |   -110 1110     |    y                   |
|xc| x  x  x  x    x  xxx |   -000 0000     |    "space"             |
|xc| x  x  x  x    x  xxx |   -111 1000     |    t                   |
|xc| x  x  x  x    x  xxx |   -111 0111     |    a                   |
|xc| x  x  x  x    x  xxx |   -111 0011     |    p                   |
|xc| x  x  x  x    x  xxx |   -111 1011     |    e                   |
|xc| x  x  x  x    x  xxx |   -101 1100     |    o                   |
|xc| x  x  x  x    x  xxx |   -001 1100     |    u                   |
|xc| x  x  x  x    x  xxx |   -111 1000     |    t                   |
|xc| x  x  x  x    x  xxx |   -111 1000     |    T                   |
`

Tests using this table are passing here: https://github.com/psychogenic/tt04-7segstringdisplay/actions