### PR TITLE
feat: allow hardening with openlane2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ idna==3.4
 importlib-resources==5.12.0
 mistune==3.0.1
 numpy==1.24.3
+openlane==2.0.7
 Pillow==9.5.0
 pycparser==2.21
 python-frontmatter==1.0.0


### PR DESCRIPTION
This patch allows hardening tt07 designs with openlane2, as a drop-in replacement for openlane1.

Note that since the tt07 shuttle is ongoing, I didn't want to change the `config.tcl` template, so as a compromise I made some patches to the configuration from `project.py` instead. Once we branch off tt08 we should rectify this.
- Openlane2 puts its `runs` directory within `DESIGN_DIR` which in our case is the `src` directory. The proper openlane2 setup would change `DESIGN_DIR` to be the root of the user repo, but `DESIGN_DIR` is also used several times in the config file and those paths have to be updated accordingly. The current workaround uses the undocumented `--force-run-dir` option.
- `MAGIC_WRITE_LEF_PINONLY` is patched into a copy of `config.tcl` in the harden() function. It should be moved to `config.tcl` itself.
- There is a warning that Tcl configuration files are deprecated and will be removed at some point. We should eventually transition either to json or to supplying a dict over the python interface.
- When writing the metrics report, openlane2 calculates utilization in a different way than openlane1. As a temporary measure I manually extract the openlane1 compatible value from the global placement logs to make comparison easier. We should find out the the reason for the difference and either switch to the new value or add the openlane1 value to the openlane2 report.