### PR TITLE
feat: add support for json config files

### DIFF
--- a/config_utils.py
+++ b/config_utils.py
@@ -1,0 +1,102 @@
+import json
+import logging
+import os
+import re
+import tkinter
+from collections.abc import Iterable
+
+import yaml
+
+
+class ConfigFileError(Exception):
+    pass
+
+
+def read_tcl_config(file: str, design_dir: str | None = None):
+    logging.warning(
+        "Support for TCL configuration files is deprecated and will be removed"
+    )
+    if design_dir is None:
+        design_dir = os.path.dirname(file)
+    design_dir = os.path.realpath(design_dir)
+    tcl_code = open(file).read()
+    interp = tkinter.Tcl()
+    interp.eval("array unset ::env")
+    interp.setvar("env(DESIGN_DIR)", design_dir)
+    config = {}
+    env_rx = re.compile(r"(?:\:\:)?env\((\w+)\)")
+
+    def py_set(key: str, value: str | None = None):
+        if match := env_rx.fullmatch(key):
+            if value is not None:
+                value = value.replace(design_dir, "dir::")
+                value = value.replace("dir::/", "dir::")
+                config[match.group(1)] = value
+
+    py_set_name = interp.register(py_set)
+    interp.call("rename", py_set_name, "_py_set")
+    interp.call("rename", "set", "_orig_set")
+    interp.eval("proc set args { _py_set {*}$args; tailcall _orig_set {*}$args; }")
+    interp.eval(tcl_code)
+    return config
+
+
+def read_json_config(file: str):
+    return json.load(open(file))
+
+
+def read_yaml_config(file: str):
+    return yaml.safe_load(open(file))
+
+
+def read_config(basename: str, formats: Iterable[str], design_dir: str | None = None):
+    for fmt in formats:
+        file = f"{basename}.{fmt}"
+        if os.path.exists(file):
+            if fmt == "tcl":
+                return read_tcl_config(file, design_dir)
+            elif fmt == "json":
+                return read_json_config(file)
+            elif fmt == "yaml":
+                return read_yaml_config(file)
+            else:
+                raise ConfigFileError(f"Unexpected configuration file format: {fmt}")
+    raise ConfigFileError(
+        f"Could not file configuration file {basename}.{{{'|'.join(formats)}}}"
+    )
+
+
+def write_tcl_config(config: dict, file: str):
+    logging.warning(
+        "Support for TCL configuration files is deprecated and will be removed"
+    )
+    with open(file, "w") as f:
+        for key, value in config.items():
+            if type(value) in (list, tuple):
+                value = " ".join(value)
+            if type(value) == str:
+                value = value.replace("dir::", "$::env(DESIGN_DIR)/")
+            print(f'set ::env({key}) "{value}"', file=f)
+
+
+def write_json_config(config: dict, file: str):
+    with open(file, "w") as f:
+        json.dump(config, f, indent=2)
+
+
+def write_yaml_config(config: dict, file: str):
+    with open(file, "w") as f:
+        yaml.safe_dump(config, f, default_flow_style=False, sort_keys=False)
+
+
+def write_config(config: dict, basename: str, formats: Iterable[str]):
+    for fmt in formats:
+        file = f"{basename}.{fmt}"
+        if fmt == "tcl":
+            write_tcl_config(config, file)
+        elif fmt == "json":
+            write_json_config(config, file)
+        elif fmt == "yaml":
+            write_yaml_config(config, file)
+        else:
+            raise ConfigFileError("Unexpected configuration file format: {fmt}")

--- a/project.py
+++ b/project.py
@@ -472,7 +472,7 @@ class Project:
         tt_version = self.get_tt_tools_version()
         workflow_url = self.get_workflow_url()
 
-        config = read_config("src/config", ("json", "tcl"))
+        config = read_config("src/config", ("yaml", "json", "tcl"))
         if self.args.openlane2:
             config["MAGIC_WRITE_LEF_PINONLY"] = "1"
         user_config = read_config("src/user_config", ("json",))

--- a/project.py
+++ b/project.py
@@ -456,7 +456,7 @@ class Project:
             "DIE_AREA": die_area,
             "FP_DEF_TEMPLATE": f"dir::../tt/def/tt_block_{tiles}_pg.def",
         }
-        write_config(config, os.path.join(self.src_dir, "user_config"), ("json", "tcl"))
+        write_config(config, os.path.join(self.src_dir, "user_config"), ("json",))
 
     def golden_harden(self):
         logging.info(f"hardening {self}")
@@ -473,8 +473,6 @@ class Project:
         workflow_url = self.get_workflow_url()
 
         config = read_config("src/config", ("yaml", "json", "tcl"))
-        if self.args.openlane2:
-            config["MAGIC_WRITE_LEF_PINONLY"] = "1"
         user_config = read_config("src/user_config", ("json",))
         config.update(user_config)
         write_config(config, "src/config_merged", ("json",))

--- a/tt_tool.py
+++ b/tt_tool.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
     # configure
     parser.add_argument(
         "--create-user-config",
-        help="create the user_config.tcl file with top module and source files",
+        help="create the user_config.json file with top module and source files",
         action="store_const",
         const=True,
     )


### PR DESCRIPTION
The first commit adds a library for reading and writing configuration files in tcl, json and yaml formats. This allows us to merge configuration files, so we no longer need to source `user_config.tcl` from `config.tcl`. Sourcing is still supported for compatibility with old `config.tcl` files, but all variables defined while evaluating `config.tcl` are overwritten by those appearing in `user_config.tcl`, creating a `config_merged.tcl` file that is used in the flow.

The second commit switches the defaults, `config.json` is now preferred over `config.tcl`, and the generated files are `user_config.json` and `config_merged.json`. We still generate `user_config.tcl` as well because an old-style `config.tcl` might still source it. We can remove that once we branch off `tt08`.

The third commit is a single-line change that also allows `config.yaml`. I've split it off so that it can be independently decided upon. I personally find `config.yaml` much more readable, but we introduce some divergence from upstream openlane. The generated files are still kept in json.

After merging the PR `tt-support-tools` should remain compatible with existing configuration files but also support these:
https://github.com/htfab/tt07-verilog-template/blob/tcl-config/src/config.tcl (doesn't source `user_config.tcl`)
https://github.com/htfab/tt07-verilog-template/blob/json-config/src/config.json
https://github.com/htfab/tt07-verilog-template/blob/yaml-config/src/config.yaml