### PR TITLE
feat(precheck): add support for 3v3 templates

### DIFF
--- a/project_info.py
+++ b/project_info.py
@@ -101,6 +101,13 @@ class ProjectInfo:
                 "Invalid value for 'analog_pins' in 'project' section, must be between 0 and 6"
             )
         self.analog_pins: int = analog_pins
+        self.is_analog: bool = self.analog_pins > 0
+
+        self.uses_3v3: bool = project_section.get("uses_3v3", False)
+        if self.uses_3v3 and not self.is_analog:
+            raise ProjectYamlError(
+                "Projects with 3v3 power need at least one analog pin"
+            )
 
         language = project_section.get("language")
         if language is None:


### PR DESCRIPTION
Notes:
- We could infer 3v3 projects either from the existence of a `VAPWR` port or from the different project area. But I think we can save ourselves from some surprises down the line if we make this choice explicit, so I've added an extra `uses_3v3` field to `info.yaml` and use that as a single source of truth.
- For this version of the precheck I'm explicitly disallowing analog / custom gds projects with zero analog pins and access to 3v3 power. It might make sense to allow it in a follow-up patch if we can handle it properly.