### PR TITLE
fix: specifying numpy version in requirements.txt for precheck

### DIFF
--- a/precheck/requirements.txt
+++ b/precheck/requirements.txt
@@ -2,3 +2,4 @@ klayout==0.29.0
 gdstk==0.9.50
 pytest==7.4.3
 PyYAML==6.0.1
+numpy==1.26.4


### PR DESCRIPTION
Even using ubuntu-22.04, the precheck action fails due to numpy 2 being installed. This adds a numpy version requirement to the precheck script, following the one used in tt08.