### PR TITLE
flow: Inherit VERILOG_DEFINES in check_ports() 

### DIFF
--- a/project.py
+++ b/project.py
@@ -160,10 +160,29 @@ class Project:
                 logging.error(f"{filename} doesn't exist in the repo")
                 exit(1)
 
+    def load_config_json(self):
+        config_json_path = os.path.join(self.src_dir, 'config.json')
+        if not os.path.exists(config_json_path):
+            return None
+        try:
+            with open(config_json_path, 'r') as f:
+                data = json.load(f)
+            return data
+        except Exception as e:
+            logging.error(f"config.json exists but could not be loaded: {type(e)}: {e}")
+            exit(1)
+
     def run_yosys(self, command: str, no_output: bool = False):
         env = os.environ.copy()
         env["YOSYS_CMD"] = command
-        yosys_cmd = 'yowasp-yosys -qp "$YOSYS_CMD"'
+        # Need to load config.json to get access to project VERILOG_DEFINES as the verilog won't parse if it has the wrong source view of the project
+        verilog_defines = os.getenv("VERILOG_DEFINES")  # highest precedence
+        if verilog_defines is None:
+            config_json = self.load_config_json()
+            if config_json and config_json["VERILOG_DEFINES"]:
+                verilog_defines = config_json["VERILOG_DEFINES"]
+        verilog_defines_list = self.resolve_arguments_to_list(verilog_defines, args_prefix='-D', kwargs_prefix='-D')
+        yosys_cmd = 'yowasp-yosys {} -qp "$YOSYS_CMD"'.format(' '.join(verilog_defines_list))
         return subprocess.run(yosys_cmd, shell=True, env=env, capture_output=no_output)
 
     def check_ports(self, include_power_ports: bool = False):


### PR DESCRIPTION
Totally untested at PR time will update on status, after this has been tested.

Doing:

```
`ifdef SIM
   $info("Hello World");
`endif

`ifndef OPENLANE_SYNTHESIS
   $info("Hello World");
`endif
```

With config.json setup `VERILOG_DEFINES = [ "OPENLANE_SYNTHESIS" ]`

Causes the TT `check_ports()` to fail.  The flow itself works fine.