### PR TITLE
Add new datasheet generation method

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -278,6 +278,20 @@ if __name__ == "__main__":
     parser.add_argument(
         "--metrics", help="print some project metrics", action="store_const", const=True
     )
+    parser.add_argument(
+        "--build-datasheet", 
+        help="build datasheet using the typst template", 
+        action="store_const", 
+        const=True
+    )
+    parser.add_argument("--doc-tapeout-index", help="path to json tapeout index")
+    parser.add_argument("--doc-content-config", help="path to json to configure datasheet content")
+    parser.add_argument(
+        "--template-version", 
+        help="set typst template version (default 1.0.0)", 
+        default="1.0.0", 
+        nargs="?"
+    )
 
     args = parser.parse_args()
 
@@ -342,3 +356,7 @@ if __name__ == "__main__":
     if args.dump_markdown:
         shuttle.configure_mux()
         docs.write_datasheet(args.dump_markdown, args.dump_pdf)
+
+    if args.build_datasheet:
+        shuttle.configure_mux()
+        docs.build_datasheet(args.template_version, args.doc_tapeout_index, args.doc_content_config)

--- a/configure.py
+++ b/configure.py
@@ -358,5 +358,4 @@ if __name__ == "__main__":
         docs.write_datasheet(args.dump_markdown, args.dump_pdf)
 
     if args.build_datasheet:
-        shuttle.configure_mux()
         docs.build_datasheet(args.template_version, args.doc_tapeout_index, args.doc_content_config)

--- a/doc_utils.py
+++ b/doc_utils.py
@@ -4,6 +4,8 @@ import logging
 
 from typing import List, Optional
 
+import chevron
+
 import matplotlib as mpl
 
 class DocsHelper:
@@ -88,13 +90,21 @@ class DocsHelper:
         return pin_table
     
     @staticmethod
-    def get_docs_as_typst(path: str) -> subprocess.CompletedProcess:
+    def get_docs_as_typst(path: str) -> str:
+        """
+        Run pandoc to convert a given file to typst
+        """
         pandoc_command = ["pandoc", path, 
                               "--shift-heading-level-by=-1", "-f", "markdown-auto_identifiers", "-t", "typst", 
                               "--columns=120"]
         logging.info(pandoc_command)
 
-        return subprocess.run(pandoc_command, capture_output=True)
+        result = subprocess.run(pandoc_command, capture_output=True)
+
+        if result.stderr != b'':
+            logging.warning(result.stderr.decode())
+
+        return result.stdout.decode()
     
     @staticmethod
     def get_project_type(language: str, is_wokwi: bool, is_analog: bool) -> str:
@@ -104,3 +114,110 @@ class DocsHelper:
             return "Analog"
         else:
             return "HDL"
+        
+    @staticmethod
+    def format_project_info(yaml_info: dict, index_info: dict) -> dict:
+        """
+        Merge two sources of project information into one dictionary
+
+        Accepts `info.yaml` from the project root, and project information from the tapeout index.
+        Using these two sources, the function will pick and merge the required information for the datasheet.
+        """
+        info = {
+            "title": yaml_info["project"]["title"],
+            "author": yaml_info["project"]["author"],
+            "description": yaml_info["project"]["description"],
+            "address": index_info["address"],
+            "clock_hz": index_info["clock_hz"],
+            "git_url": index_info["repo"],
+            "language": yaml_info["project"]["language"],
+            "macro": index_info["macro"],
+            "is_analog": len(index_info["analog_pins"]) > 0,
+            "is_wokwi": True if "wokwi_id" in yaml_info["project"] else False,
+            "type": "project"
+        }
+
+        if info["is_wokwi"]:
+            info["wokwi_id"] = yaml_info["project"]["wokwi_id"]
+
+        try:
+            info["pins"] = [
+                {
+                    "pin_index": str(i),
+                    "ui": index_info["pinout"][f"ui[{i}]"],
+                    "uo": index_info["pinout"][f"uo[{i}]"],
+                    "uio": index_info["pinout"][f"uio[{i}]"],
+                } for i in range(8)
+            ]
+        except KeyError as e:
+            logging.info(f"project is missing a pin entry ({e}), falling back to info.yaml (is this a subtile?)")
+
+            info["pins"] = [
+                {
+                    "pin_index": str(i),
+                    "ui": yaml_info["pinout"][f"ui[{i}]"],
+                    "uo": yaml_info["pinout"][f"uo[{i}]"],
+                    "uio": yaml_info["pinout"][f"uio[{i}]"],
+                } for i in range(8)
+            ]
+
+        if info["is_analog"]:
+            info["analog_pins"] = [
+                {
+                    "ua_index": str(i),
+                    "analog_index": index_info["analog_pins"][i],
+                    "desc": index_info["pinout"][f"ua[{i}]"],
+                } for i in range(len(index_info["analog_pins"]))
+            ]
+
+
+        if "type" in index_info:
+            if index_info["type"] == "subtile":
+                info["type"] = "subtile"
+                info["subtile_addr"] = index_info["subtile_addr"]
+                info["subtile_group"] = index_info["subtile_group"]
+            
+            elif index_info["type"] == "group":
+                info["type"] = "group"
+
+        return info
+
+    @staticmethod
+    def write_doc(path: str, template: str, content: dict) -> None:
+        try:
+            with open(path, "w") as f:
+                f.write(chevron.render(template, content))
+        except FileNotFoundError as e:
+            logging.warning(f"unable to write to {path}... the project exists in tapeout index, but not in local directory? skipping")
+
+    @staticmethod
+    def populate_template_tags(info: dict, danger_info: dict, docs: str, template_version = "1.0.0") -> dict:       
+        """
+        Populate the required template fields given information about the project and its danger level
+        """
+        content = {
+            "template-version": template_version,
+            "project-title": info["title"].replace('"', '\\"'),
+            "project-author": f"({DocsHelper.format_authors(info["author"])})",
+            "project-repo-link": info["git_url"],
+            "project-description": info["description"],
+            "project-address": DocsHelper.pretty_address(info["address"]),
+            "project-clock": DocsHelper.pretty_clock(info["clock_hz"]),
+            "project-type": DocsHelper.get_project_type(info["language"], info["is_wokwi"], info["is_analog"]),
+            "project-doc-body": docs,
+            "digital-pins": DocsHelper.format_digital_pins(info["pins"]),
+        }
+
+        if info["macro"] in danger_info:
+            content["is-dangerous"] = True
+            content["project-danger-level"] = danger_info[info["macro"]]["level"]
+            content["project-danger-reason"] = danger_info[info["macro"]]["reason"] 
+
+        if info["type"] == "subtile":
+            content["project-address"] = DocsHelper.pretty_address(info["address"], info["subtile_addr"])
+
+        if info["is_wokwi"]:
+            content["is-wokwi"] = True
+            content["project-wokwi-id"] = info["wokwi_id"]
+
+        return content

--- a/doc_utils.py
+++ b/doc_utils.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 import matplotlib as mpl
 
 class DocsHelper:
+    @staticmethod
     def pretty_address(address: int, subtile_address: Optional[int] = None) -> str:
         """
         Format the address and subtile address (if applicable) into an nice string for the typst template
@@ -16,6 +17,7 @@ class DocsHelper:
             content += f"/{subtile_address}"
         return content
     
+    @staticmethod
     def pretty_clock(clock: int) -> str:
         """
         Format the clock with engineering notation
@@ -33,7 +35,8 @@ class DocsHelper:
             return f"{hz_as_eng[0]} Hz"
         else:
             raise RuntimeError("unexpected amount of entries when formatting clock for datasheet")
-        
+    
+    @staticmethod
     def format_authors(authors: str) -> str:
         """
         Format the authors properly
@@ -59,29 +62,32 @@ class DocsHelper:
         """
         return text.replace("[", "\\[").replace("]", "\\]")
     
-    def format_digital_pins(self, pins: dict) -> str:
+    @staticmethod
+    def format_digital_pins(pins: dict) -> str:
         """
         Iterate through and create the digital pin table as a string
         """
         pin_table = ""
         for pin in pins:
-            ui_text = self._escape_square_brackets(pin["ui"])
-            uo_text = self._escape_square_brackets(pin["uo"])
-            uio_text = self._escape_square_brackets(pin["uio"])
+            ui_text = DocsHelper._escape_square_brackets(pin["ui"])
+            uo_text = DocsHelper._escape_square_brackets(pin["uo"])
+            uio_text = DocsHelper._escape_square_brackets(pin["uio"])
             pin_table += f"[`{pin["pin_index"]}`], [{ui_text}], [{uo_text}], [{uio_text}],\n"
 
         return pin_table
     
-    def format_analog_pins(self, pins: dict):
+    @staticmethod
+    def format_analog_pins(pins: dict):
         """
         Iterate through and create the analog pin table as a string
         """
         pin_table = ""
         for pin in pins:
-            desc_text = self._escape_square_brackets(pin["desc"])
+            desc_text = DocsHelper._escape_square_brackets(pin["desc"])
             pin_table += f"[`{pin["ua_index"]}`], [`{pin["analog_index"]}`], [{desc_text}],\n"
         return pin_table
     
+    @staticmethod
     def get_docs_as_typst(path: str) -> subprocess.CompletedProcess:
         pandoc_command = ["pandoc", path, 
                               "--shift-heading-level-by=-1", "-f", "markdown-auto_identifiers", "-t", "typst", 
@@ -89,3 +95,12 @@ class DocsHelper:
         logging.info(pandoc_command)
 
         return subprocess.run(pandoc_command, capture_output=True)
+    
+    @staticmethod
+    def get_project_type(language: str, is_wokwi: bool, is_analog: bool) -> str:
+        if is_wokwi:
+            return "Wokwi"
+        elif is_analog:
+            return "Analog"
+        else:
+            return "HDL"

--- a/doc_utils.py
+++ b/doc_utils.py
@@ -1,0 +1,91 @@
+import re
+import subprocess
+import logging
+
+from typing import List, Optional
+
+import matplotlib as mpl
+
+class DocsHelper:
+    def pretty_address(address: int, subtile_address: Optional[int] = None) -> str:
+        """
+        Format the address and subtile address (if applicable) into an nice string for the typst template
+        """
+        content = str(address).rjust(4, "-")
+        if subtile_address != None:
+            content += f"/{subtile_address}"
+        return content
+    
+    def pretty_clock(clock: int) -> str:
+        """
+        Format the clock with engineering notation
+        """
+        if clock == 0:
+            return "No Clock"
+        else:
+            formatter = mpl.ticker.EngFormatter(sep=" ")
+            # [clock, SI suffix]
+            hz_as_eng = formatter(clock).split(" ")
+
+        if len(hz_as_eng) == 2:
+            return f"{hz_as_eng[0]} {hz_as_eng[1]}Hz"
+        elif len(hz_as_eng) == 1:
+            return f"{hz_as_eng[0]} Hz"
+        else:
+            raise RuntimeError("unexpected amount of entries when formatting clock for datasheet")
+        
+    def format_authors(authors: str) -> str:
+        """
+        Format the authors properly
+
+        Split the authors with a set of delimiters, then repackage as a typst array for the template
+        """
+        split_authors = re.split(r"[,|;|+]| and | & ", authors)
+        formatted_authors = []
+        for author in split_authors:
+            stripped = author.strip()
+            if stripped == "":
+                continue
+
+            # typst needs a trailing comma if len(array) == 1, so that it doesn't interpret it as an expression
+            # https://typst.app/docs/reference/foundations/array/
+            formatted_authors.append(f"\"{stripped}\",")
+        return "".join(formatted_authors)
+    
+    @staticmethod
+    def _escape_square_brackets(text: str) -> str:
+        """
+        Helper function to escape square brackets in strings
+        """
+        return text.replace("[", "\\[").replace("]", "\\]")
+    
+    def format_digital_pins(self, pins: dict) -> str:
+        """
+        Iterate through and create the digital pin table as a string
+        """
+        pin_table = ""
+        for pin in pins:
+            ui_text = self._escape_square_brackets(pin["ui"])
+            uo_text = self._escape_square_brackets(pin["uo"])
+            uio_text = self._escape_square_brackets(pin["uio"])
+            pin_table += f"[`{pin["pin_index"]}`], [{ui_text}], [{uo_text}], [{uio_text}],\n"
+
+        return pin_table
+    
+    def format_analog_pins(self, pins: dict):
+        """
+        Iterate through and create the analog pin table as a string
+        """
+        pin_table = ""
+        for pin in pins:
+            desc_text = self._escape_square_brackets(pin["desc"])
+            pin_table += f"[`{pin["ua_index"]}`], [`{pin["analog_index"]}`], [{desc_text}],\n"
+        return pin_table
+    
+    def get_docs_as_typst(path: str) -> subprocess.CompletedProcess:
+        pandoc_command = ["pandoc", path, 
+                              "--shift-heading-level-by=-1", "-f", "markdown-auto_identifiers", "-t", "typst", 
+                              "--columns=120"]
+        logging.info(pandoc_command)
+
+        return subprocess.run(pandoc_command, capture_output=True)

--- a/docs/user_project.typ.mustache
+++ b/docs/user_project.typ.mustache
@@ -2,10 +2,10 @@
 
 #show: tt.project.with(
     title: "{{project-title}}",
-    author: {{project-author}},
+    author: {{&project-author}},
     repo-link: "{{project-repo-link}}",
     description: "{{&project-description}}",
-    address: "{{project-address}}",
+    address: "{{&project-address}}",
     clock: "{{project-clock}}",
     type: "{{project-type}}",
     {{#is-wokwi}}

--- a/docs/user_project.typ.mustache
+++ b/docs/user_project.typ.mustache
@@ -25,7 +25,7 @@
     columns: 4,
     align: left,
     table.header(
-        [\\#], [Input], [Output], [Bidirectional]
+        [\#], [Input], [Output], [Bidirectional]
     ),
     {{&digital-pins}}
 )]
@@ -36,7 +36,7 @@
     columns: 3,
     align: left,
     table.header(
-        [`ua`\\#], [`analog`\\#], [Description]
+        [`ua`\#], [`analog`\#], [Description]
     ),
     {{&analog-pins}}
 )]

--- a/docs/user_project.typ.mustache
+++ b/docs/user_project.typ.mustache
@@ -1,7 +1,7 @@
 #import "@local/tt-datasheet:{{template-version}}" as tt
 
 #show: tt.project.with(
-    title: "{{project-title}}",
+    title: "{{&project-title}}",
     author: {{&project-author}},
     repo-link: "{{project-repo-link}}",
     description: "{{&project-description}}",

--- a/docs/user_project.typ.mustache
+++ b/docs/user_project.typ.mustache
@@ -1,0 +1,45 @@
+#import "@local/tt-datasheet:{{template-version}}" as tt
+
+#show: tt.project.with(
+    title: {{project-title}},
+    author: {{project-author}},
+    repo-link: {{project-repo-link}},
+    description: {{project-description}},
+    address: {{project-address}},
+    clock: {{project-clock}},
+    type: {{project-type}},
+
+    {{#is-wokwi}}
+    wokwi-id: {{project-wokwi-id}},
+    {{/is-wokwi}}
+
+    {{#is-dangerous}}
+    danger-level: {{project-danger-level}},
+    danger-reason: {{project-danger-reason}},
+    {{/is-dangerous}}
+)
+
+{{project-doc-body}}
+
+= Project Pinout
+== Digital Pins
+#align(center)[#table(
+    columns: 4,
+    align: left,
+    table.header(
+        [\\#], [Input], [Output], [Bidirectional]
+    ),
+    {{digital-pins}}
+)]
+
+{{#is-analog}}
+== Analog Pins
+#align(center)[#table(
+    columns: 3,
+    align: left,
+    table.header(
+        [`ua`\\#], [`analog`\\#], [Description]
+    ),
+    {{analog-pins}}
+)]
+{{/is-analog}}

--- a/docs/user_project.typ.mustache
+++ b/docs/user_project.typ.mustache
@@ -1,25 +1,23 @@
 #import "@local/tt-datasheet:{{template-version}}" as tt
 
 #show: tt.project.with(
-    title: {{project-title}},
+    title: "{{project-title}}",
     author: {{project-author}},
-    repo-link: {{project-repo-link}},
-    description: {{project-description}},
-    address: {{project-address}},
-    clock: {{project-clock}},
-    type: {{project-type}},
-
+    repo-link: "{{project-repo-link}}",
+    description: "{{&project-description}}",
+    address: "{{project-address}}",
+    clock: "{{project-clock}}",
+    type: "{{project-type}}",
     {{#is-wokwi}}
-    wokwi-id: {{project-wokwi-id}},
+    wokwi-id: "{{project-wokwi-id}}",
     {{/is-wokwi}}
-
     {{#is-dangerous}}
-    danger-level: {{project-danger-level}},
-    danger-reason: {{project-danger-reason}},
+    danger-level: "{{project-danger-level}}",
+    danger-reason: "{{project-danger-reason}}",
     {{/is-dangerous}}
 )
 
-{{project-doc-body}}
+{{&project-doc-body}}
 
 = Project Pinout
 == Digital Pins
@@ -29,7 +27,7 @@
     table.header(
         [\\#], [Input], [Output], [Bidirectional]
     ),
-    {{digital-pins}}
+    {{&digital-pins}}
 )]
 
 {{#is-analog}}
@@ -40,6 +38,6 @@
     table.header(
         [`ua`\\#], [`analog`\\#], [Description]
     ),
-    {{analog-pins}}
+    {{&analog-pins}}
 )]
 {{/is-analog}}

--- a/documentation.py
+++ b/documentation.py
@@ -192,7 +192,11 @@ class Docs:
             logging.warning("danger_level.yaml not found")
         else:
             with open(os.path.abspath("./projects/danger_level.yaml"), "r") as f:
-                danger_info = yaml.safe_load(f)
+                content = yaml.safe_load(f)
+                # yaml.safe_load() returns None for an empty file
+                # check before overwriting since we rely on danger_info being a dict later
+                if content != None:
+                    danger_info = content
         
         project_template = self.load_doc_template("user_project.typ.mustache")
 

--- a/documentation.py
+++ b/documentation.py
@@ -17,6 +17,17 @@ from git_utils import get_first_remote
 from markdown_utils import rewrite_image_paths
 from project import Project
 
+class DocsHelper:
+    def pretty_address(address: int, subtile_address: Optional[int] = None) -> str:
+        """
+        Format the address and subtile address (if applicable) into an nice string for the typst template
+        """
+        content = str(address).rjust(4, "-")
+        if subtile_address != None:
+            content += f"/{subtile_address}"
+        return content
+    
+
 
 class Docs:
     def __init__(self, config: Config, projects: List[Project]):
@@ -280,10 +291,6 @@ class Docs:
                     )                
                     art_index += 1
 
-            # format project address
-            # TODO: subtile addr
-            project_address = str(project.mux_address).rjust(4, "-")
-
             if project.info.clock_hz == 0:
                 pretty_clock = "No Clock"
             else:
@@ -328,7 +335,7 @@ class Docs:
                 "project-author": f"({formatted_authors})",
                 "project-repo-link": yaml_data["git_url"],
                 "project-description": yaml_data["description"],
-                "project-address": project_address,
+                "project-address": DocsHelper.pretty_address(project.mux_address),
                 "project-clock": pretty_clock,
                 "project-type": yaml_data["project_type"],
                 "project-doc-body": result.stdout.decode(),

--- a/documentation.py
+++ b/documentation.py
@@ -296,7 +296,7 @@ class Docs:
 
             content = {
                 "template-version": template_version,
-                "project-title": yaml_data["title"],
+                "project-title": yaml_data["title"].replace('"', '\\"'),
                 "project-author": f"({formatted_authors})",
                 "project-repo-link": yaml_data["git_url"],
                 "project-description": yaml_data["description"],

--- a/documentation.py
+++ b/documentation.py
@@ -263,28 +263,25 @@ class Docs:
             # insert artwork
             current_project += 1
             if total_available_art != None:
-                if art_index >= len(datasheet_content_config["artwork"]):
-                    continue
-
-                if current_project % insert_art_after == 0:
-                    details = datasheet_content_config["artwork"][art_index]
-                    datasheet_manifest.append(
-                        f"#tt.art(\"{details["id"]}\", rot:{details["rotate"]})\n"
-                    )                
-                    art_index += 1
-
+                if not (art_index >= len(datasheet_content_config["artwork"])):
+                    if current_project % insert_art_after == 0:
+                        details = datasheet_content_config["artwork"][art_index]
+                        datasheet_manifest.append(
+                            f"#tt.art(\"{details["id"]}\", rot:{details["rotate"]})\n"
+                        )                
+                        art_index += 1
+        
             content = {
                 "template-version": template_version,
                 "project-title": yaml_data["title"].replace('"', '\\"'),
-                "project-author": f"({DocsHelper.format_authors(yaml_data["authors"])})",
+                "project-author": f"({DocsHelper.format_authors(yaml_data["author"])})",
                 "project-repo-link": yaml_data["git_url"],
                 "project-description": yaml_data["description"],
                 "project-address": DocsHelper.pretty_address(project.mux_address),
                 "project-clock": DocsHelper.pretty_clock(project.info.clock_hz),
-                "project-type": yaml_data["project_type"],
+                "project-type": DocsHelper.get_project_type(yaml_data["language"], project.is_wokwi(), yaml_data["is_analog"]),
                 "project-doc-body": result.stdout.decode(),
                 "digital-pins": DocsHelper.format_digital_pins(yaml_data["pins"]),
-                "is-analog": yaml_data["is_analog"],
             }
 
             if project.is_wokwi():

--- a/documentation.py
+++ b/documentation.py
@@ -2,7 +2,6 @@ import logging
 import os
 import subprocess
 import json
-import re
 import math
 from typing import List, Optional
 
@@ -10,97 +9,12 @@ import chevron
 import frontmatter  # type: ignore
 import git  # type: ignore
 import yaml
-import matplotlib as mpl
 
 from config import Config
 from git_utils import get_first_remote
 from markdown_utils import rewrite_image_paths
 from project import Project
-
-class DocsHelper:
-    def pretty_address(address: int, subtile_address: Optional[int] = None) -> str:
-        """
-        Format the address and subtile address (if applicable) into an nice string for the typst template
-        """
-        content = str(address).rjust(4, "-")
-        if subtile_address != None:
-            content += f"/{subtile_address}"
-        return content
-    
-    def pretty_clock(clock: int) -> str:
-        """
-        Format the clock with engineering notation
-        """
-        if clock == 0:
-            return "No Clock"
-        else:
-            formatter = mpl.ticker.EngFormatter(sep=" ")
-            # [clock, SI suffix]
-            hz_as_eng = formatter(clock).split(" ")
-
-        if len(hz_as_eng) == 2:
-            return f"{hz_as_eng[0]} {hz_as_eng[1]}Hz"
-        elif len(hz_as_eng) == 1:
-            return f"{hz_as_eng[0]} Hz"
-        else:
-            raise RuntimeError("unexpected amount of entries when formatting clock for datasheet")
-        
-    def format_authors(authors: str) -> str:
-        """
-        Format the authors properly
-
-        Split the authors with a set of delimiters, then repackage as a typst array for the template
-        """
-        split_authors = re.split(r"[,|;|+]| and | & ", authors)
-        formatted_authors = []
-        for author in split_authors:
-            stripped = author.strip()
-            if stripped == "":
-                continue
-
-            # typst needs a trailing comma if len(array) == 1, so that it doesn't interpret it as an expression
-            # https://typst.app/docs/reference/foundations/array/
-            formatted_authors.append(f"\"{stripped}\",")
-        return "".join(formatted_authors)
-    
-    @staticmethod
-    def _escape_square_brackets(text: str) -> str:
-        """
-        Helper function to escape square brackets in strings
-        """
-        return text.replace("[", "\\[").replace("]", "\\]")
-    
-    def format_digital_pins(self, pins: dict) -> str:
-        """
-        Iterate through and create the digital pin table as a string
-        """
-        pin_table = ""
-        for pin in pins:
-            ui_text = self._escape_square_brackets(pin["ui"])
-            uo_text = self._escape_square_brackets(pin["uo"])
-            uio_text = self._escape_square_brackets(pin["uio"])
-            pin_table += f"[`{pin["pin_index"]}`], [{ui_text}], [{uo_text}], [{uio_text}],\n"
-
-        return pin_table
-    
-    def format_analog_pins(self, pins: dict):
-        """
-        Iterate through and create the analog pin table as a string
-        """
-        pin_table = ""
-        for pin in pins:
-            desc_text = self._escape_square_brackets(pin["desc"])
-            pin_table += f"[`{pin["ua_index"]}`], [`{pin["analog_index"]}`], [{desc_text}],\n"
-        return pin_table
-    
-    def get_docs_as_typst(project_macro: str) -> subprocess.CompletedProcess:
-        pandoc_command = ["pandoc", f"projects/{project_macro}/docs/info.md", 
-                              "--shift-heading-level-by=-1", "-f", "markdown-auto_identifiers", "-t", "typst", 
-                              "--columns=120"]
-        logging.info(pandoc_command)
-
-        return subprocess.run(pandoc_command, capture_output=True)
-
+from doc_utils import DocsHelper
 
 class Docs:
     def __init__(self, config: Config, projects: List[Project]):
@@ -334,7 +248,7 @@ class Docs:
                 )
 
             logging.info(f"building datasheet for {project}")
-            result = DocsHelper.get_docs_as_typst(project.get_macro_name())
+            result = DocsHelper.get_docs_as_typst(f"projects/{project.get_macro_name()}/docs/info.md")
 
             if result.stderr != b'':
                 logging.warning(result.stderr.decode())

--- a/documentation.py
+++ b/documentation.py
@@ -92,6 +92,14 @@ class DocsHelper:
             desc_text = self._escape_square_brackets(pin["desc"])
             pin_table += f"[`{pin["ua_index"]}`], [`{pin["analog_index"]}`], [{desc_text}],\n"
         return pin_table
+    
+    def get_docs_as_typst(project_macro: str) -> subprocess.CompletedProcess:
+        pandoc_command = ["pandoc", f"projects/{project_macro}/docs/info.md", 
+                              "--shift-heading-level-by=-1", "-f", "markdown-auto_identifiers", "-t", "typst", 
+                              "--columns=120"]
+        logging.info(pandoc_command)
+
+        return subprocess.run(pandoc_command, capture_output=True)
 
 
 class Docs:
@@ -326,12 +334,7 @@ class Docs:
                 )
 
             logging.info(f"building datasheet for {project}")
-
-            pandoc_command = ["pandoc", f"projects/{project.get_macro_name()}/docs/info.md", 
-                              "--shift-heading-level-by=-1", "-f", "markdown-auto_identifiers", "-t", "typst", 
-                              "--columns=120"]
-            logging.info(pandoc_command)
-            result = subprocess.run(pandoc_command, capture_output=True)
+            result = DocsHelper.get_docs_as_typst(project.get_macro_name())
 
             if result.stderr != b'':
                 logging.warning(result.stderr.decode())

--- a/documentation.py
+++ b/documentation.py
@@ -197,7 +197,8 @@ class Docs:
                 if content != None:
                     danger_info = content
         
-        project_template = self.load_doc_template("user_project.typ.mustache")
+        with open(os.path.join(self.script_dir, "docs/user_project.typ.mustache")) as f:
+            project_template = f.read()
 
         datasheet_manifest = [
             f"#import \"@local/tt-datasheet:{template_version}\" as tt\n"

--- a/documentation.py
+++ b/documentation.py
@@ -27,6 +27,23 @@ class DocsHelper:
             content += f"/{subtile_address}"
         return content
     
+    def pretty_clock(clock: int) -> str:
+        """
+        Format the clock with engineering notation
+        """
+        if clock == 0:
+            return "No Clock"
+        else:
+            formatter = mpl.ticker.EngFormatter(sep=" ")
+            # [clock, SI suffix]
+            hz_as_eng = formatter(clock).split(" ")
+
+        if len(hz_as_eng) == 2:
+            return f"{hz_as_eng[0]} {hz_as_eng[1]}Hz"
+        elif len(hz_as_eng) == 1:
+            return f"{hz_as_eng[0]} Hz"
+        else:
+            raise RuntimeError("unexpected amount of entries when formatting clock for datasheet")
 
 
 class Docs:
@@ -336,7 +353,7 @@ class Docs:
                 "project-repo-link": yaml_data["git_url"],
                 "project-description": yaml_data["description"],
                 "project-address": DocsHelper.pretty_address(project.mux_address),
-                "project-clock": pretty_clock,
+                "project-clock": DocsHelper.pretty_clock(project.info.clock_hz),
                 "project-type": yaml_data["project_type"],
                 "project-doc-body": result.stdout.decode(),
                 "digital-pins": digital_pin_table,

--- a/documentation.py
+++ b/documentation.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import json
 import re
+import math
 from typing import List, Optional
 
 import chevron
@@ -204,6 +205,17 @@ class Docs:
             f"#import \"@local/tt-datasheet:{template_version}\" as tt\n"
         ]
 
+        # handle art
+        current_project = 0
+        art_index = 0
+        total_available_art = None
+        if datasheet_content_config != None and "artwork" in datasheet_content_config:
+            total_available_art = len(datasheet_content_config["artwork"])
+
+        if total_available_art != None:
+            if total_available_art > 0:
+                insert_art_after = math.floor(len(self.projects) / total_available_art)
+
         for project in self.projects:           
             yaml_data = project.get_project_docs_dict()
             analog_pins = project.info.analog_pins
@@ -255,6 +267,18 @@ class Docs:
             else:
                 datasheet_manifest.append(include_proj_str)
 
+            # insert artwork
+            current_project += 1
+            if total_available_art != None:
+                if art_index >= len(datasheet_content_config["artwork"]):
+                    continue
+
+                if current_project % insert_art_after == 0:
+                    details = datasheet_content_config["artwork"][art_index]
+                    datasheet_manifest.append(
+                        f"#tt.art(\"{details["id"]}\", rot:{details["rotate"]})\n"
+                    )                
+                    art_index += 1
 
             # format project address
             # TODO: subtile addr

--- a/project.py
+++ b/project.py
@@ -755,8 +755,6 @@ class Project:
             project_template = f.read()
 
         result = DocsHelper.get_docs_as_typst(os.path.join(self.local_dir, "docs/info.md"))
-        if result.stderr != b'':
-            logging.warning(result.stderr.decode())
 
         content = {
             "template-version": template_version,
@@ -767,7 +765,7 @@ class Project:
             "project-address": "----",
             "project-clock": DocsHelper.pretty_clock(self.info.clock_hz),
             "project-type": DocsHelper.get_project_type(template_args["language"], self.is_wokwi(), template_args["is_analog"]),
-            "project-doc-body": result.stdout.decode(),
+            "project-doc-body": result,
             "digital-pins": DocsHelper.format_digital_pins(template_args["pins"]),
         }
 

--- a/project.py
+++ b/project.py
@@ -21,6 +21,7 @@ from config_utils import read_config, write_config
 from markdown_utils import limit_markdown_headings
 from project_info import ProjectInfo, ProjectYamlError
 from tech import TechName, tech_map
+from doc_utils import DocsHelper
 
 PINOUT_KEYS = [
     "ui[0]",
@@ -721,6 +722,66 @@ class Project:
         if p.returncode != 0:
             logging.error("pdf generation failed")
             raise RuntimeError(f"pdf generation failed with code {p.returncode}")
+
+    def create_project_datasheet(self, template_version: str):
+        template_args = copy.deepcopy(self.info.__dict__)
+        template_args.update(
+            {
+                "pins": [
+                    {
+                        "pin_index": str(i),
+                        "ui": self.info.pinout.ui[i],
+                        "uo": self.info.pinout.uo[i],
+                        "uio": self.info.pinout.uio[i],
+                    }
+                    for i in range(8)
+                ],
+                "analog_pins": [
+                    {
+                        "ua_index": str(i),
+                        "analog_index": "?",
+                        "desc": desc,
+                    }
+                    for i, desc in enumerate(self.info.pinout.ua)
+                ],
+                "is_analog": self.info.is_analog,
+                "uses_3v3": self.info.uses_3v3,
+            }
+        )
+
+        logging.info("creating project datasheet")
+
+        with open(os.path.join(SCRIPT_DIR, "docs/user_project.typ.mustache")) as f:
+            project_template = f.read()
+
+        result = DocsHelper.get_docs_as_typst(os.path.join(self.local_dir, "docs/info.md"))
+        if result.stderr != b'':
+            logging.warning(result.stderr.decode())
+
+        content = {
+            "template-version": template_version,
+            "project-title": template_args["title"].replace('"', '\\"'),
+            "project-author": f"({DocsHelper.format_authors(template_args["author"])})",
+            "project-repo-link": "placeholder git repo link",
+            "project-description": template_args["description"],
+            "project-address": "----",
+            "project-clock": DocsHelper.pretty_clock(self.info.clock_hz),
+            "project-type": DocsHelper.get_project_type(template_args["language"], self.is_wokwi(), template_args["is_analog"]),
+            "project-doc-body": result.stdout.decode(),
+            "digital-pins": DocsHelper.format_digital_pins(template_args["pins"]),
+        }
+
+        if self.is_wokwi():
+            content["is-wokwi"] = True
+            content["project-wokwi-id"] = self.info.wokwi_id
+
+        if template_args["is_analog"]:
+            content["is-analog"] = True
+            content["analog-pins"] = DocsHelper.format_analog_pins(template_args["analog_pins"])
+        
+        with open(os.path.abspath(f"./docs/doc.typ"), "w") as f:
+            logging.info("writing datasheet to ./docs/doc.typ")
+            f.write(chevron.render(project_template, content))
 
     # Read and return top-level GDS data from the final GDS file, using gdstk:
     def get_final_gds_top_cells(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "PyYAML",
     "requests",
     "yowasp-yosys",
+    "matplotlib"
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,12 @@ click==8.2.1
     # via yowasp-yosys
 cocotb==2.0.0
     # via tt-support-tools (pyproject.toml)
+contourpy==1.3.3
+    # via matplotlib
 cssselect2==0.8.0
     # via cairosvg
+cycler==0.12.1
+    # via matplotlib
 defusedxml==0.7.1
     # via cairosvg
 distlib==0.4.0
@@ -32,6 +36,8 @@ filelock==3.18.0
     # via virtualenv
 find-libpython==0.4.1
     # via cocotb
+fonttools==4.60.1
+    # via matplotlib
 gdstk==0.9.60
     # via tt-support-tools (pyproject.toml)
 gitdb==4.0.12
@@ -46,7 +52,11 @@ importlib-resources==6.5.2
     # via wasmtime
 iniconfig==2.1.0
     # via pytest
+kiwisolver==1.4.9
+    # via matplotlib
 klayout==0.29.12
+    # via tt-support-tools (pyproject.toml)
+matplotlib==3.10.6
     # via tt-support-tools (pyproject.toml)
 mistune==3.1.3
     # via tt-support-tools (pyproject.toml)
@@ -54,12 +64,18 @@ nodeenv==1.9.1
     # via pre-commit
 numpy==1.26.4
     # via
+    #   contourpy
     #   gdstk
+    #   matplotlib
     #   tt-support-tools (pyproject.toml)
 packaging==25.0
-    # via pytest
+    # via
+    #   matplotlib
+    #   pytest
 pillow==11.3.0
-    # via cairosvg
+    # via
+    #   cairosvg
+    #   matplotlib
 platformdirs==4.3.8
     # via
     #   virtualenv
@@ -72,8 +88,12 @@ pycparser==2.22
     # via cffi
 pygments==2.19.2
     # via pytest
+pyparsing==3.2.5
+    # via matplotlib
 pytest==8.4.2
     # via tt-support-tools (pyproject.toml)
+python-dateutil==2.9.0.post0
+    # via matplotlib
 python-frontmatter==1.1.0
     # via tt-support-tools (pyproject.toml)
 pyyaml==6.0.2
@@ -83,6 +103,8 @@ pyyaml==6.0.2
     #   tt-support-tools (pyproject.toml)
 requests==2.32.4
     # via tt-support-tools (pyproject.toml)
+six==1.17.0
+    # via python-dateutil
 smmap==5.0.2
     # via gitdb
 tinycss2==1.4.0

--- a/tt_tool.py
+++ b/tt_tool.py
@@ -223,7 +223,7 @@ if __name__ == "__main__":
     if args.create_pdf:
         project.create_pdf()
 
-    if args.create_project_datasheet():
+    if args.create_project_datasheet:
         project.create_project_datasheet(args.template_version)
 
     if args.create_png:

--- a/tt_tool.py
+++ b/tt_tool.py
@@ -87,6 +87,18 @@ if __name__ == "__main__":
         const=True,
     )
     parser.add_argument(
+        "--create-project-datasheet",
+        help="create a datasheet for the current project",
+        action="store_const",
+        const=True
+    )
+    parser.add_argument(
+        "--template-version", 
+        help="set typst template version (default 1.0.0)", 
+        default="1.0.0", 
+        nargs="?"
+    )
+    parser.add_argument(
         "--create-svg",
         help="create a svg of the GDS layout",
         action="store_const",
@@ -210,6 +222,9 @@ if __name__ == "__main__":
 
     if args.create_pdf:
         project.create_pdf()
+
+    if args.create_project_datasheet():
+        project.create_project_datasheet(args.template_version)
 
     if args.create_png:
         project.create_png()


### PR DESCRIPTION
This PR adds new functions in order to generate shuttle/project datasheets using the typst template. New CLI options were also added, as I did not want to overwrite the existing method you have in place.

 To generate a single project datasheet, from the root of the project, do:
```bash
python3 tt/tt_tool.py --create-project-datasheet
```

To generate the shuttle datasheet, you must pass the tapeout index to it (and optionally a content config file):
```bash
python3 tt/configure.py --build-datasheet --doc-tapeout-index ttihp25a.json [--doc-content-config datasheet_config.json]
```

The content config file is a json file that looks something like:
```json
{
    "version": 1,
    "disabled": [
        "tt_um_failing_project_datasheet"    
    ],
    "artwork": [
        {
            "id": "image-from-template1", "rotate": "90deg"
        }
    ]
}
```
It controls which projects are enabled/disabled, and adds artwork in between the projects (if any have been defined).

When building the datasheets, the script will enter each project docs directory and write a `doc.typ` file. This file contains the markdown content converted to typst along with the boilerplate needed. 

If building the shuttle datasheet, the path of each projects' `doc.typ` is then written to a `datasheet_manifest.typ` which stores the order and artwork of the project. This `datasheet_manifest.typ` file is then included by the main typst file (`datasheet.typ`) that instantiates the datasheet template. This main typst file can then be compiled into the final PDF.

Currently the script will error out if `datasheet.typ` doesn't exist in the root of the shuttle directory, perhaps it's worth removing it? The idea behind it was that, in the context of a workflow run, there's no point compiling and converting all the docs if it won't be able to be used at the end.

An example `datasheet.typ`:
```typ
#import "@local/tt-datasheet:1.0.0" as tt

#show: tt.datasheet.with(
  shuttle: "IHP 25A",
  repo-link: "https://github.com/tinytapeout/tinytapeout-ihp-25a",
  theme: "bold",
  theme-override-colour: rgb("#196126"),
  projects: include "datasheet_manifest.typ",
  // chip-viewer-link: "https://tinytapeout.com/decap/dummy"
)


#tt.funding[
  IHP PDK support for Tiny Tapeout was funded by The SwissChips Initiative.

  The manufacturing of Tiny Tapeout IHP 0p2 silicon was funded by the German BMBF project FMD-QNC (16ME0831).
]

#tt.renders(
  // sponsor-text: "Decap sponsored by",
  // sponsor-logo: tt.get-image-by-id("asset", "decap-sponsor-here"),
  {
    tt.add-render("GDS", image("/docs/images/full_gds.png"))
    tt.add-render("Logic Density", image("/docs/images/logic_density.png"), subtitle: "Local Interconnect Layer")
  }
)
```