### PR TITLE
tt_fpga: remove set_frequency from .pcf so nextpnr --freq works as expected

### DIFF
--- a/fpga/tt_fpga_fabricfoxv2.pcf
+++ b/fpga/tt_fpga_fabricfoxv2.pcf
@@ -33,5 +33,3 @@ set_io -nowarn uo_out[4] 45
 set_io -nowarn uo_out[5] 46
 set_io -nowarn uo_out[6] 47
 set_io -nowarn uo_out[7] 48
-
-set_frequency clk  24.0


### PR DESCRIPTION
My first experience trying to use the TT FPGA board to harden tt08-nyan died with this:

> ERROR: Max frequency for clock 'clk$SB_IO_IN_$glb_clk': 18.31 MHz (FAIL at 24.00 MHz)

Couldn't figure out where the 24MHz was coming from, discovered the TT_FPGA_FREQ option but it didn't work.

fpga/tt_fpga_fabricfoxv2.pcf has `set_frequency 24MHz` which prevents the nextpnr-ice40 --freq option from working at all, and timing failures are fatal by default. Setting this option allows the compilation to work, assuming the timing checks are very conservative.