### PR TITLE
fix(docs): make project doc flow compatible with updated template

### DIFF
--- a/project.py
+++ b/project.py
@@ -668,10 +668,10 @@ class Project:
 
         content = {
             "template_version": template_version,
-            "project_title": template_args["title"].replace('"', '\\"'),
+            "project_title": f'str("{DocsHelper._escape_characters_in_string(template_args["title"])}")',
             "project_author": f"({DocsHelper.format_authors(template_args['author'])})",
             "project_repo_link": self.get_git_remote(),
-            "project_description": template_args["description"],
+            "project_description": f'str("{DocsHelper._escape_characters_in_string(template_args["description"])}")',
             "project_address": "----",
             "project_clock": DocsHelper.pretty_clock(self.info.clock_hz),
             "project_type": DocsHelper.get_project_type(


### PR DESCRIPTION
The shuttle datasheet flow was updated to sanitise strings properly, and within the changes were some updates to the template that was used. This template is shared between the shuttle and individual projects, but the standalone version wasn't updated to be compatible. This commit rectifies that issue.

Reported in Discord and tested against their project (https://github.com/YannGuidon/miniMAC_tx/actions/runs/22810729227/job/66167101834).

Ref #156  (and I guess #157 too)