### PR TITLE
feat: add Nix devshell flake for macOS local hardening (no Docker)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,91 @@
+{
+  description = "TT support tools development environment for TTSKY26a hardening";
+
+  inputs = {
+    librelane.url = "github:librelane/librelane";
+  };
+
+  outputs = { self, librelane, ... }: let
+    forAllSystems = librelane.inputs.nix-eda.forAllSystems;
+  in {
+    devShells = forAllSystems (system: let
+      nixpkgs = librelane.inputs.nix-eda.inputs.nixpkgs;
+      devshell = librelane.inputs.devshell;
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [
+          devshell.overlays.default
+          librelane.inputs.nix-eda.overlays.default
+          librelane.overlays.default
+          (final: prev: prev.lib.optionalAttrs prev.stdenv.isDarwin {
+            # ghdl-mcode is Linux-only; stub it out on macOS so cocotb can be built
+            # without VHDL simulation support (which we don't need).
+            ghdl-mcode = prev.runCommand "ghdl-mcode-stub" {} "mkdir $out";
+            python3 = prev.python3.override {
+              packageOverrides = pyFinal: pyPrev: {
+                # nixpkgs pins cocotb 1.8.1 which uses MODULE= env var.
+                # tt-support-tools test Makefile uses COCOTB_TEST_MODULES= (cocotb 2.x API).
+                # Override with cocotb 2.0.1 from PyPI.
+                find-libpython = pyPrev.find-libpython.overridePythonAttrs (_: rec {
+                  version = "0.5.1";
+                  src = prev.fetchurl {
+                    url = "https://files.pythonhosted.org/packages/source/f/find_libpython/find_libpython-${version}.tar.gz";
+                    sha256 = "1zjranrffz2l782acpcfq72ai91f2jyv2m6m1ynn9k4dzwwzp80j";
+                  };
+                  doCheck = false;
+                });
+                cocotb = pyPrev.cocotb.overridePythonAttrs (_: rec {
+                  version = "2.0.1";
+                  src = prev.fetchurl {
+                    url = "https://files.pythonhosted.org/packages/source/c/cocotb/cocotb-${version}.tar.gz";
+                    sha256 = "10jfg238wba7vbbb9hyhjjdg2vqzvb0dd6jpz2c3xx1g8547g239";
+                  };
+                  patches = [];
+                  doCheck = false;
+                });
+              };
+            };
+          })
+        ];
+      };
+    in {
+      default = pkgs.callPackage (librelane.createOpenLaneShell {
+
+        extra-packages = with pkgs;
+          pkgs.lib.optionals stdenv.isDarwin [
+            cairo
+          ];
+
+        extra-env = pkgs.lib.optionals pkgs.stdenv.isDarwin [
+          {
+            name = "DYLD_LIBRARY_PATH";
+            value = "${pkgs.gfortran.cc.lib}/lib:${pkgs.cairo}/lib";
+          }
+        ];
+
+        extra-python-packages = with pkgs.python3.pkgs; [
+          # tt-support-tools direct dependencies
+          cairosvg
+          chevron
+          cocotb
+          configupdater
+          find-libpython
+          gitpython
+          mistune
+          pillow
+          pytest
+          python-frontmatter
+
+          # transitive dependencies
+          cffi
+          cssselect2
+          defusedxml
+          smmap
+          tinycss2
+          webencodings
+        ];
+
+      }) {};
+    });
+  };
+}


### PR DESCRIPTION
## Summary

Adds a `flake.nix` to `tt-support-tools` that enables a fully
Nix-based local hardening flow on macOS without Docker or a Python
virtual environment.

## Motivation

The Docker-based local hardening flow has two significant limitations
on macOS:
- `--open-in-klayout` and `--open-in-openroad` do not work because
  the LibreLane Docker image is Linux-only and the Qt xcb display
  plugin cannot connect to the macOS display server
- The setup requires managing a Homebrew Python venv, cairo native
  library, and PATH conflicts with oss-cad-suite

The Nix-based flow resolves both issues. All EDA tools run natively
via LibreLane's existing Nix environment, and GUI tools work because
they have direct access to the macOS display.

## How it works

The `flake.nix` takes LibreLane's flake as an input and extends its
devshell using the `createOpenLaneShell` function already provided
by LibreLane for this purpose. It adds:
- `cairo` native library (macOS only) so `cairosvg` can find it
- All `tt-support-tools` Python dependencies not already in
  LibreLane's environment
- A macOS overlay that stubs out `ghdl-mcode` (Linux-only) so
  `cocotb` can be built, and overrides cocotb to 2.0.1 (nixpkgs
  24.05 has 1.8.1 which uses a different test module API)

## Validated on macOS Apple Silicon (aarch64-darwin)

- ✅ `--create-user-config`
- ✅ `--harden --no-docker`
- ✅ `--open-in-klayout --no-docker` (works natively — not possible in Docker flow)
- ✅ `--open-in-openroad --no-docker` (works natively — not possible in Docker flow)
- ✅ RTL simulation (`make -B`)
- ✅ Gate-level simulation (`make -B GATES=yes`)
- ⚠️ `--create-png` not available (nixpkgs 24.05 numpy/gdstk packaging
  issue on Apple Silicon — does not affect hardening or submission)

## Dependencies

This PR requires the lazy import fixes from #161 to work correctly.
Without those fixes, `tt_tool.py` crashes at startup due to
top-level imports of `matplotlib` and `gdstk` which are not
available in the Nix environment.

## Notes

- Linux support is untested but the overlay is scoped to
  `isDarwin` so it should not affect Linux users
- The `flake.lock` is not included — it will be generated on first
  `nix develop` invocation
