### PR TITLE
fix(precheck/sky130A): add MR_licon.SP.6_overlap rule to MR

### DIFF
--- a/precheck/tech-files/sky130A_mr.drc
+++ b/precheck/tech-files/sky130A_mr.drc
@@ -903,6 +903,10 @@ if FEOL
         "MR_licon.SP.6",
         "MR_licon.SP.6 : poly_licon minimum space to psdm (overlap prohibited) : 0.11um"
     )
+    poly_licon_all.interacting(psdm).output(
+        "MR_licon.SP.6_overlap",
+        "MR_licon.SP.6 : licon and psdm must not overlap"
+    )
     
     # MR_licon.SP.8: licon on diff minimum space to gate outside areaid:standardc (overlap prohibited) ≥ 0.055
     licon_on_diff = licon.and(difftap)


### PR DESCRIPTION
as suggested by @smunaut