### PR TITLE
fix(precheck/sky130A): Fix MR_licon.SP6 again

### DIFF
--- a/precheck/tech-files/sky130A_mr.drc
+++ b/precheck/tech-files/sky130A_mr.drc
@@ -898,12 +898,12 @@ if FEOL
     )
     
     # MR_licon.SP.6: poly_licon minimum space to psdm (overlap prohibited) ≥ 0.11
-    poly_licon_all = licon.and(poly)
-    poly_licon_all.separation(psdm, 0.11, euclidian).output(
+    poly_licon_not_prec_resistor = licon_not_prec_resistor.and(poly)
+    poly_licon_not_prec_resistor.separation(psdm, 0.11, euclidian).output(
         "MR_licon.SP.6",
         "MR_licon.SP.6 : poly_licon minimum space to psdm (overlap prohibited) : 0.11um"
     )
-    poly_licon_all.interacting(psdm).output(
+    poly_licon_not_prec_resistor.interacting(psdm).output(
         "MR_licon.SP.6_overlap",
         "MR_licon.SP.6 : licon and psdm must not overlap"
     )


### PR DESCRIPTION
Previous fix caused issue with resistors since that check must not apply to anything in prec_res zone according to licon.9

I rechecked against : 
* Design with resistor that was causing false positive -> Now is clean as it should
* SRAM design with psdm over licon -> Properly flags DRC error
* New SRAM design that was fixed -> Clean
* Old TT9 design that had a proximity violation -> Properly flags DRC error