### PR TITLE
fix(fpga): Use --project-dir for harden and configure

### DIFF
--- a/tt_fpga.py
+++ b/tt_fpga.py
@@ -267,7 +267,8 @@ class TTFPGA:
         sources = [os.path.join(self.source_dir, src) for src in self.sources]
         source_list = " ".join(sources)
 
-        yosys_cmd = f"yosys -l {build_dir}/01-synth.log -DSYNTH -p 'read_verilog -sv src/_tt_fpga_top.v {source_list}; synth_ice40 -top tt_fpga_top -json {build_dir}/{base_name}.json'"
+        top_module_filename = os.path.join(self.source_dir, "_tt_fpga_top.v")
+        yosys_cmd = f"yosys -l {build_dir}/01-synth.log -DSYNTH -p 'read_verilog -sv {top_module_filename} {source_list}; synth_ice40 -top tt_fpga_top -json {build_dir}/{base_name}.json'"
         logging.debug(yosys_cmd)
         p = subprocess.run(yosys_cmd, shell=True)
         if p.returncode != 0:
@@ -324,7 +325,7 @@ def main():
     elif args.command == CommandConfig:
         proj_name = fpga.get_name()
         bitstream_name = f"{proj_name}.bin"
-        fname = f"build/{bitstream_name}"
+        fname = os.path.join(fpga.local_dir, "build", bitstream_name)
         if not os.path.exists(fname):
             print(f"Can't find {fname}")
             sys.exit(3)


### PR DESCRIPTION
Right now, running `tt_fpga.py --project-dir example/<projectname>
harden` will fail if previously, `tt_fpga.py harden` was ran against a
project in the root folder. This is because the `_tt_fpga_top.v` file is
always read from `src/_tt_fpga_top.v`, even though it's generated in the
proper --project-dir location.

Similar problem affects the `configure` command, where it looks for the
bitstream in `build/<name>.bin` relative to the current dir even with
`--project-dir` set.

Commit prepends the source_dir from `--project-dir` in the appropriate
places such that it's used for both harden and configure.

Tested by observing that running the following commands in sequence now
succeeds against one of my projects:
- tt_fpga.py harden
- tt_fpga.py --project-dir examples/tt_um_vga_example_gamepad harden
- tt_fpga.py --project-dir examples/tt_um_vga_example_gamepad configure
    --upload --port /dev/ttyACM0